### PR TITLE
chore: disable no-import-prefix

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,6 +7,15 @@
   },
   "lock": false,
   "fmt": {
-    "exclude": ["CHANGELOG.md"]
+    "exclude": [
+      "CHANGELOG.md"
+    ]
+  },
+  "lint": {
+    "rules": {
+      "exclude": [
+        "no-import-prefix"
+      ]
+    }
   }
 }


### PR DESCRIPTION
we dont use deno.lock and deno.jsonc (what is differ from package.json?)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted configuration file structure for improved readability.
  * Added a new lint rule exclusion to project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->